### PR TITLE
Draft logic for non-breaking spaces.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,14 @@ function walk (tree, indent, indentDefault, adjust) {
 
 function sanitize (tree) {
   return tree.reduce((m, node) => {
+    const last = m.length ? m[m.length - 1] : null
+    if (last && last.type === 'tag' &&
+      node.type === 'text' && node.content === ' ') {
+      node.content = '&nbsp;'
+      m.push(node)
+      return m
+    }
+
     // remove any existing indents
     if (node.type === 'text' && node.content.match(/^\s+$/)) { return m }
 

--- a/test/fixtures/inline_code.expected.html
+++ b/test/fixtures/inline_code.expected.html
@@ -1,0 +1,3 @@
+<div>
+  <p><a href="/link">link</a>&nbsp;<code>foo</code></p>
+</div>

--- a/test/fixtures/inline_code.html
+++ b/test/fixtures/inline_code.html
@@ -1,0 +1,3 @@
+<div>
+        <p><a href="/link">link</a> <code>foo</code></p>
+</div>

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,10 @@ test('basic', (t) => {
   return compare(t, 'basic')
 })
 
+test('inline_code', (t) => {
+  return compare(t, 'inline_code')
+})
+
 test('strips and replaces existing indentation', (t) => {
   return compare(t, 'bad_indents')
 })


### PR DESCRIPTION
Ok, here is a quite crude attempt to fix the problem, let me know what you think.

Really we should know that the previous tag element is an inline element. Otherwise things like `<div><div></div> </div>` will be converted to something like:

```
<div>
  <div></div>&nbsp;
</div>
```